### PR TITLE
Optional functionality to annotated in order

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ $ python app.py /images/directory
 ```
 $ python app.py /images/directory --out test.csv
 ```
+* Additionally, you can specify a separator character which will split the file names into string and integer portions when sorting the file order ('_' is the default)
+```
+$ python app.py /images/directory -s "_"
+```
+* If you do not wish to sort the order in which the images appear, set the no sort option to True (False is the default)
+```
+$ python app.py /images/directory --out test.csv --no_sort True
+```
 * open http://127.0.0.1:5000/tagger in your browser
     * only tested on Chrome
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,4 @@
-import sys
 from os import walk
-import imghdr
-import csv
 import argparse
 
 from flask import Flask, redirect, url_for, request
@@ -12,6 +9,7 @@ from flask import send_file
 app = Flask(__name__)
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 
+
 @app.route('/tagger')
 def tagger():
     if (app.config["HEAD"] == len(app.config["FILES"])):
@@ -21,27 +19,31 @@ def tagger():
     labels = app.config["LABELS"]
     not_end = not(app.config["HEAD"] == len(app.config["FILES"]) - 1)
     print(not_end)
-    return render_template('tagger.html', not_end=not_end, directory=directory, image=image, labels=labels, head=app.config["HEAD"] + 1, len=len(app.config["FILES"]))
+    return render_template(
+        'tagger.html', not_end=not_end, directory=directory, image=image, labels=labels,
+        head=app.config["HEAD"] + 1, len=len(app.config["FILES"])
+    )
+
 
 @app.route('/next')
 def next():
     image = app.config["FILES"][app.config["HEAD"]]
     app.config["HEAD"] = app.config["HEAD"] + 1
-    with open(app.config["OUT"],'a') as f:
+    with open(app.config["OUT"], 'a') as f:
         for label in app.config["LABELS"]:
-            f.write(image + "," +
-            label["id"] + "," +
-            label["name"] + "," +
-            str(round(float(label["xMin"]))) + "," +
-            str(round(float(label["xMax"]))) + "," +
-            str(round(float(label["yMin"]))) + "," +
-            str(round(float(label["yMax"]))) + "\n")
+            f.write(
+                (image + "," + label["id"] + "," + label["name"] + "," + str(round(float(label["xMin"]))) + "," +
+                 str(round(float(label["xMax"]))) + "," + str(round(float(label["yMin"]))) + "," +
+                 str(round(float(label["yMax"]))) + "\n")
+            )
     app.config["LABELS"] = []
     return redirect(url_for('tagger'))
+
 
 @app.route("/bye")
 def bye():
     return send_file("taf.gif", mimetype='image/gif')
+
 
 @app.route('/add/<id>')
 def add(id):
@@ -49,8 +51,9 @@ def add(id):
     xMax = request.args.get("xMax")
     yMin = request.args.get("yMin")
     yMax = request.args.get("yMax")
-    app.config["LABELS"].append({"id":id, "name":"", "xMin":xMin, "xMax":xMax, "yMin":yMin, "yMax":yMax})
+    app.config["LABELS"].append({"id": id, "name": "", "xMin": xMin, "xMax": xMax, "yMin": yMin, "yMax": yMax})
     return redirect(url_for('tagger'))
+
 
 @app.route('/remove/<id>')
 def remove(id):
@@ -59,6 +62,7 @@ def remove(id):
     for label in app.config["LABELS"][index:]:
         label["id"] = str(int(label["id"]) - 1)
     return redirect(url_for('tagger'))
+
 
 @app.route('/label/<id>')
 def label(id):
@@ -71,6 +75,7 @@ def label(id):
 #     app.config["HEAD"] = app.config["HEAD"] - 1
 #     return redirect(url_for('tagger'))
 
+
 @app.route('/image/<f>')
 def images(f):
     images = app.config['IMAGES']
@@ -81,26 +86,41 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('dir', type=str, help='specify the images directory')
     parser.add_argument("--out")
+    parser.add_argument(
+        "-s",
+        "--separator",
+        help="The character which separates the string and integer portions of the files names",
+        default="_"
+    )
+    parser.add_argument(
+        "--no_sort",
+        help="Toggle between sorting and not sorting the order in which the images are displayed",
+        default=False
+    )
     args = parser.parse_args()
     directory = args.dir
+    separator_character = str(args.separator)
     if directory[len(directory) - 1] != "/":
-         directory += "/"
+        directory += "/"
     app.config["IMAGES"] = directory
     app.config["LABELS"] = []
     files = None
     for (dirpath, dirnames, filenames) in walk(app.config["IMAGES"]):
-        files = filenames
+        if args.no_sort:
+            files = filenames
+        else:
+            files = sorted(filenames, key=lambda a: int(a.split(separator_character)[1][:-len(".png")]))
         break
-    if files == None:
+    if files is None:
         print("No files")
         exit()
     app.config["FILES"] = files
     app.config["HEAD"] = 0
-    if args.out == None:
+    if args.out is None:
         app.config["OUT"] = "out.csv"
     else:
         app.config["OUT"] = args.out
     print(files)
-    with open("out.csv",'w') as f:
+    with open("out.csv", 'w') as f:
         f.write("image,id,name,xMin,xMax,yMin,yMax\n")
     app.run(debug="True")


### PR DESCRIPTION
At the moment, there aren't any options to traverse the target directory in different orders. I was using this tool to annotate PNG files named: file_1, file_2, ... , frame_10, frame_11, etc. I found it useful to have the files displayed for annotating in a more intuitive order rather than frame_1, frame_10, frame_11, etc. Maybe others will find this useful as well.

The original functionality can be maintained by not including the extra command line arguments. I have added these instructions to the README file.

I also made some minor formatting changes to that my linter (flake8) did not raise any errors.